### PR TITLE
Use external scanner logic to distinguish between arrays & subscripts

### DIFF
--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2332,70 +2332,46 @@
       ]
     },
     "element_reference": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "PREC_LEFT",
-          "value": 0,
-          "content": {
-            "type": "SEQ",
+      "type": "PREC_LEFT",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "object",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_primary"
+            }
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_element_reference_bracket"
+            },
+            "named": false,
+            "value": "["
+          },
+          {
+            "type": "CHOICE",
             "members": [
-              {
-                "type": "FIELD",
-                "name": "object",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_primary"
-                }
-              },
               {
                 "type": "SYMBOL",
-                "name": "_array_reference"
+                "name": "_argument_list_with_trailing_comma"
+              },
+              {
+                "type": "BLANK"
               }
             ]
+          },
+          {
+            "type": "STRING",
+            "value": "]"
           }
-        },
-        {
-          "type": "PREC_LEFT",
-          "value": 90,
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "FIELD",
-                "name": "object",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_primary"
-                }
-              },
-              {
-                "type": "IMMEDIATE_TOKEN",
-                "content": {
-                  "type": "STRING",
-                  "value": "["
-                }
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "_argument_list_with_trailing_comma"
-                  },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
-              },
-              {
-                "type": "STRING",
-                "value": "]"
-              }
-            ]
-          }
-        }
-      ]
+        ]
+      }
     },
     "scope_resolution": {
       "type": "PREC_LEFT",
@@ -2891,100 +2867,6 @@
               }
             }
           ]
-        },
-        {
-          "type": "PREC",
-          "value": 1,
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "_call"
-                  },
-                  {
-                    "type": "FIELD",
-                    "name": "method",
-                    "content": {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "SYMBOL",
-                          "name": "_variable"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "scope_resolution"
-                        }
-                      ]
-                    }
-                  }
-                ]
-              },
-              {
-                "type": "SYMBOL",
-                "name": "array"
-              },
-              {
-                "type": "FIELD",
-                "name": "block",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "block"
-                }
-              }
-            ]
-          }
-        },
-        {
-          "type": "PREC",
-          "value": -1,
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "_call"
-                  },
-                  {
-                    "type": "FIELD",
-                    "name": "method",
-                    "content": {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "SYMBOL",
-                          "name": "_variable"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "scope_resolution"
-                        }
-                      ]
-                    }
-                  }
-                ]
-              },
-              {
-                "type": "SYMBOL",
-                "name": "array"
-              },
-              {
-                "type": "FIELD",
-                "name": "block",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "do_block"
-                }
-              }
-            ]
-          }
         },
         {
           "type": "PREC",
@@ -5814,10 +5696,6 @@
       }
     },
     "array": {
-      "type": "SYMBOL",
-      "name": "_array_reference"
-    },
-    "_array_reference": {
       "type": "SEQ",
       "members": [
         {
@@ -6105,18 +5983,7 @@
       "value": "\\s|\\\\\\n"
     }
   ],
-  "conflicts": [
-    [
-      "_lhs",
-      "call"
-    ],
-    [
-      "_lhs",
-      "call",
-      "command_call",
-      "command_call_with_block"
-    ]
-  ],
+  "conflicts": [],
   "externals": [
     {
       "type": "SYMBOL",
@@ -6213,6 +6080,10 @@
     {
       "type": "SYMBOL",
       "name": "_binary_star_star"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_element_reference_bracket"
     }
   ],
   "inline": [],

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1016,16 +1016,6 @@
           }
         ]
       }
-    },
-    "children": {
-      "multiple": false,
-      "required": false,
-      "types": [
-        {
-          "type": "array",
-          "named": true
-        }
-      ]
     }
   },
   {

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -38,6 +38,7 @@ enum TokenType {
   HASH_KEY_SYMBOL,
   HASH_SPLAT_STAR_STAR,
   BINARY_STAR_STAR,
+  ELEMENT_REFERENCE_BRACKET,
 
   NONE
 };
@@ -224,7 +225,7 @@ struct Scanner {
           }
           break;
         default:
-          if (crossed_newline && lexer->lookahead != '.' && lexer->lookahead != '&') {
+          if (crossed_newline && lexer->lookahead != '.' && lexer->lookahead != '&' && lexer->lookahead != '#') {
             lexer->result_symbol = LINE_BREAK;
           }
           return true;
@@ -321,7 +322,6 @@ struct Scanner {
   }
 
   bool scan_symbol_identifier(TSLexer *lexer) {
-
     if (lexer->lookahead == '@') {
       advance(lexer);
       if (lexer->lookahead == '@') {
@@ -873,6 +873,20 @@ struct Scanner {
           }
 
           return false;
+        }
+        break;
+
+      case '[':
+        // Treat a square bracket as an element reference if either:
+        // * the bracket is not preceded by any whitespace
+        // * an arbitrary expression is not valid at the current position.
+        if (valid_symbols[ELEMENT_REFERENCE_BRACKET] && (
+          !has_leading_whitespace ||
+          !valid_symbols[STRING_START]
+        )) {
+          advance(lexer);
+          lexer->result_symbol = ELEMENT_REFERENCE_BRACKET;
+          return true;
         }
         break;
 

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1314,7 +1314,7 @@ end
 (program
   (call
     (identifier)
-    (array (integer))
+    (argument_list (array (integer)))
     (block (block_parameters (identifier)) (identifier)))
   (call
     (identifier)


### PR DESCRIPTION
When an opening square bracket appears immediately after a callable expression like "a" or "a.b", we must decide between two possible interpretations of the bracket:
1. It could be part of an element reference, as in
   `a[0] = true`.
2. Or it could be an array literal, passed as an argument, as in
   `puts [1, 2, 3]`

If there is no preceding whitespace, the bracket should *always* be treated as part of an element reference. This matches MRI's behavior.

If there *is* preceding whitespace, MRI makes its decision in a context-sensitive way, based on whether the preceding expression is a local variable or a method name.

This parser is not context-sensitive, so we instead will interpret the bracket as part of an array literal whenever that is syntactically valid, and interpret it as part of element reference otherwise. The external scanner can use the validity of other expression tokens like `string` to infer whether an array literal would be valid.